### PR TITLE
Enforce uniqueness of GCM regid in MobileClient

### DIFF
--- a/src/AssoMaker/PHPMBundle/Controller/MobileClientController.php
+++ b/src/AssoMaker/PHPMBundle/Controller/MobileClientController.php
@@ -51,13 +51,15 @@ class MobileClientController extends Controller
         $request = $this->getRequest();
         $gcm_regid = $request->request->get('regid', '');
         $em = $this->getDoctrine()->getEntityManager();
-       
-        $entity  = new MobileClient();
-        $entity->setGcm_regid($gcm_regid);
-        $em->persist($entity);
-        $em->flush();
-        
-        
+
+        $entity = $em->getRepository('AssoMakerPHPMBundle:MobileClient')->findBy(array('gcm_regid' => $gcm_regid));
+        if (!$entity) {
+            $entity  = new MobileClient();
+            $entity->setGcm_regid($gcm_regid);
+            $em->persist($entity);
+            $em->flush();
+        }
+
         $response = new Response();
         $response->setContent(json_encode("ok"));
         $response->headers->set('Content-Type', 'application/json');

--- a/src/AssoMaker/PHPMBundle/Entity/MobileClient.php
+++ b/src/AssoMaker/PHPMBundle/Entity/MobileClient.php
@@ -2,12 +2,14 @@
 
 namespace AssoMaker\PHPMBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * MobileClient
  *
  * @ORM\Table()
  * @ORM\Entity
+ * @UniqueEntity("email")
  */
 class MobileClient
 {
@@ -23,7 +25,7 @@ class MobileClient
     /**
      * @var text $gcm_regid
      *
-     * @ORM\Column(name="gcm_regid", type="text", nullable=true)
+     * @ORM\Column(name="gcm_regid", type="text", nullable=true, unique=true)
      */
     protected $gcm_regid;
     


### PR DESCRIPTION
En principe Doctrine devrait péter une erreur, par contre ce serait mieux de tester si le regid est déja en base, et de ne rien faire dans ce cas.